### PR TITLE
Merged with version v3.0 (47b4dc) 

### DIFF
--- a/htdocs/css/info.css
+++ b/htdocs/css/info.css
@@ -133,7 +133,7 @@
     color: #F9D276;
 }
 
-.infoothernames ul, .infolocation ul, .infoarea ul{
+.infoothernames ul, .infolocation ul, .inforelations ul, .infoarea ul{
     margin-left: -40px;
     margin-top: 0px;
     margin-bottom: 0px;

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -762,7 +762,7 @@
     <div id="version">
         <div id="versioncontent" class="center unselectable defaultcursor">
             <a href="/forum/viewtopic.php?t=12" title="To the forum post">
-                <span>v.3.0</span>
+                <span>v.3.a</span>
                 <span class="small">Beta</span>
             </a>
         </div>
@@ -914,17 +914,16 @@
             Journey
         </div>
         <div id='scalebar' class="unselectable">
-            <div id="scalebarslider" style="height: 3px; padding:1px; margin:0 5px 0 5px;"></div>
+        <div id="scalebarslider" style="height: 3px; padding:1px; margin:0 5px 0 5px;"></div>
             <div id='scalebarheader'>Scalebar (miles)</div>
             <div id='scalebarsmooth' title="smooth has bad effects on slow machines!">smooth</div>
-            <div id='scalebarleft'>0</div>
-            <div id='scalebarcenter'>
-            </div>
+            <div id='scalebarleft'>0 </div>
+            <div id='scalebarcenter'></div>
             <div id='scalebarright'></div>
         </div>
         <div id='arda-bg' class="clickable defaultButton imagebutton">
-            <span style="margin-top: 20px; position: absolute; margin-left: 5px;" title="Show Earth" alt="Switching views">Earth</span>
-            <img src="pics/Earth.png" title="Show Earth" alt="Switching views">
+        <span style="margin-top: 20px; position: absolute; margin-left: 5px;" title="Show Earth" alt="Switching views">Earth</span>
+        <img src="pics/Earth.png" title="Show Earth" alt="Switching views">
         </div>
         <div id='regionbutton' class="clickable defaultButton buttonlarge unselectable">
             Region
@@ -1130,11 +1129,11 @@
     <script src="js/libs/jquery.jscrollpane.min.js" type="text/javascript"></script>
     <script src="js/db.js" type="text/javascript"></script>
     <script src="js/welcome.js" type="text/javascript"></script>
+    <script src="js/info.js" type="text/javascript"></script>
     <script src="js/orientdb.js" type="text/javascript"></script>
     <script src="js/popup.js" type="text/javascript"></script>
     <script src="js/footerpopup.js" type="text/javascript"></script>
     <script src="js/illustrator.js" type="text/javascript"></script>
-    <script src="js/info.js" type="text/javascript"></script>
     <script src="js/legend.js" type="text/javascript"></script>
     <script src="js/journey.js" type="text/javascript"></script>
     <script src="js/timeline.js" type="text/javascript"></script>

--- a/htdocs/js/familytree-d3.js
+++ b/htdocs/js/familytree-d3.js
@@ -1,398 +1,475 @@
 var familytree = (function() {
-    var svg, link = {}, node = {};
-    var force = d3.layout.force();
-    var zoom;
-    var width = 1200, height = 900;
-    var container;
-    var events     = d3.dispatch("node_click", "node_dblclick", "node_contextmenu"),
-        markerEnds = d3.range(1, 9).reduce(function(m, d) {
-            return (m[d] = "url(#end" + d + ")", m)
-        }, {});
-
-    return {
-        initializeGraph: (function() {
-            force
-                .size([width, height])
-                .gravity(.2)
-                .charge(-400)
-                .friction(0.9)
-                .theta(0.9)
-                .linkStrength(1)
-                .distance(100)
-                .on("tick", tick);
-            return function(dataSet) {
-                force
-                    .nodes(dataSet.nodes)
-                    .links(dataSet.links);
-                svg = zoomableSVG({width: "100%", height: "100%"}, "#familytreecontentsvg", {extent: [0.4, 4], dblclk: null});
-
-                svg.onZoom(zoomed);
-
-                hookDrag(force.drag(), "dragstart.force", function(d) {
-                    //prevent dragging on the nodes from dragging the canvas
-                    var e = d3.event.sourceEvent;
-                    e.preventDefault();
-                    if(e.button != 2) {
-                        //left click only
-                        e.stopPropagation();
-                        d.fixed = e.shiftKey || e.touches && (e.touches.length > 1);
-                        familytree.click(d)
-                    }
-                });
-                hookDrag(force.drag(), "dragend.force", function(d) {
-                    //prevent dragging on the nodes from dragging the canvas
-                    var e = d3.event.sourceEvent;
-                    d.fixed = e.shiftKey || d.fixed;
-                });
-
-                var varsvgMarker = svg.selectAll("defs")
-                    .data([["end"]])
-                    .enter().append("defs")
-                    .selectAll("marker")
-                    .data(id)
-                    .enter();
-                familytree.createMarker(varsvgMarker);
-
-                container = svg.selectAll("#container").data([{nodes: [force.nodes()], links: [force.links()]}]);
-                container.enter().append("g").attr("id", "container");
-
-                var links = container.selectAll(".links").data(function(d) {
-                    return d.links
-                });
-                links.enter().append("g").attr("class", "links");
-
-                link = links.selectAll("line").data(id);
-                link.enter().append("line")/*.attr("class", "link")*/;
-                link.exit().remove();
-                link.attr("class", function(d) {
-                    if(d.relation == "BEGETS") {
-                        return "linkBEGETS";
-                    }
-                    if(d.relation == "LOVES") {
-                        return "linkLOVES";
-                    }
-                    if(d.relation == "HASSIBLING") {
-                        return "linkHASSIBLING";
-                    }
-                })
-                    .attr("marker-end", function(d) {
-                        if(d.relation == "BEGETS") {
-                            return markerEnds[d.targetSign] || "url(#end1)"
-                        }
-                    });
-
-                var nodes = container.selectAll(".nodes").data(function(d) {
-                    return d.nodes
-                });
-                nodes.enter().append("g").attr("class", "nodes");
-
-                node = nodes.selectAll(".node").data(id, nodeKey);
-                var newNode = node.enter().append("g").attr("class", "node");
-                node.exit().remove();
-                newNode
-                    .on("mouseover", familytree.mouseover)
-                    .on("mouseout", familytree.mouseout)
-                    .on("dblclick", function(d) {
-                        familytree.dblclick(d);
-                    })
-                    .on('contextmenu', function(data, index) {
-                        d3.event.preventDefault();
-                        familytree.events.node_contextmenu(data, index);
-                    })
-                    .call(force.drag);
-                newNode
-                    .append("circle")
-                    .attr("class", "bgcircle");
-                node.select("circle")
-                    .attr("r", function(d) {
-                        return Math.abs(familytree.posXY(d));
-                    })
-                    .style("fill", function(d) {
-                        return familytree.colourRace(d);
-                    })
-                    .style("stroke", function(d) {
-                        return familytree.colourRace(d);
-                    });
-                newNode
-                    .append("svg:image")
-                    .attr("class", "circle")
-                    .attr("xlink:href", imgHref)
-                    .attr("width", function(d) {
-                        return familytree.sizeXY(d);
-                    })
-                    .attr("height", function(d) {
-                        return familytree.sizeXY(d);
-                    })
-                    .on("error", function() {
-                        d3.select(this).style("visibility", "hidden");
-                    });
-                node.select("image")
-                    .attr("x", function(d) {
-                        return familytree.posXY(d);
-                    })
-                    .attr("y", function(d) {
-                        return familytree.posXY(d);
-                    });
-                newNode
-                    .append("text")
-                    .attr("class", "nodetext");
-                node.select("text")
-                    .attr("x", function(d) {
-                        return Math.abs(familytree.posXY(d) - 5);
-                    })
-                    .attr("y", 4)
-                    .text(function(d) {
-                        return d.name;
-                    });
-
-                force
-                    .alpha(0.4)
-                    .start();
-
-                function hookDrag(target, event, hook) {
-                    //hook force.drag behaviour
-                    var stdDragStart = target.on(event);
-                    target.on(event, function(d) {
-                        hook.call(this, d);
-                        stdDragStart.call(this, d);
-                    });
-                }
-
-                function zoomed() {
-                    var e       = d3.event.sourceEvent,
-                        isWheel = e && ((e.type == "mousewheel") || (e.type == "wheel"));
-                    force.alpha(0.01);
-                    return isWheel ? zoomWheel.call(this) : zoomInst.call(this)
-                }
-
-                function zoomInst() {
-                    var t = d3.transform(container.attr("transform"));
-                    t.translate = d3.event.translate;
-                    t.scale = d3.event.scale;
-                    container.attr("transform", t.toString());
-                }
-
-                function zoomWheel() {
-                    var t = d3.transform(container.attr("transform"));
-                    t.translate = d3.event.translate;
-                    t.scale = d3.event.scale;
-                    container.transition().duration(450).attr("transform", t.toString());
-                }
-
-                function imgHref(d) {
-                    return "/pics/arda/creature/" + d.uniquename + "_familytree.png";
-                }
-
-                function nodeKey(d, i) {
-                    return this.href ? d3.select(this).attr("href") : imgHref(d);
-                }
-
-            };
-
-            function tick() {
-                link
-                    .attr("x1", function(d) {
-                        return d.source.x;
-                    })
-                    .attr("y1", function(d) {
-                        return d.source.y;
-                    })
-                    .attr("x2", function(d) {
-                        return d.target.x;
-                    })
-                    .attr("y2", function(d) {
-                        return d.target.y;
-                    });
-                node
-                    .attr("transform", function(d) {
-                        return "translate(" + d.x + "," + d.y + ")";
-                    });
-            }
-
-        })(),
-        createMarker   : function(svg) {
-            var obj = [38, 43, 50, 54, 60, 65, 70, 80, 85];
-            for (var i = 0; i < obj.length; i++) {
-                svg.append("svg:marker")
-                    .attr("id", "end" + (i + 1))
-                    .attr("viewBox", "0 -5 10 10")
-                    .attr("refX", obj[i])
-                    .attr("refY", -0.05)
-                    .attr("markerWidth", 6)
-                    .attr("markerHeight", 6)
-                    .attr("orient", "auto")
-                    .append("svg:path")
-                    .attr("d", "M0,-4L10,0L0,4");
-            }
-        },
-        sizeXY         : function(d) {
-            var deflt = -10;
-            return [deflt, 20, 24, 28, 32, 36, 40, 44, 48, 52][d.significance || 0] || deflt;
-        },
-        posXY          : function(d) {
-            var deflt = 10;
-            return [deflt, -10, -12, -14, -16, -18, -20, -22, -24, -26][d.significance || 0] || deflt;
-        },
-        colourRace     : function(d) {
-            switch((d.race)) {
-                case "Ainu":
-                    return "#000";
-                    break;
-                case "Arnorian":
-                    return "#5D8AA8";
-                    break;
-                case "Balrog":
-                    return "#000";
-                    break;
-                case "Dragon":
-                    return "#900";
-                    break;
-                case "Dwarf":
-                    return "#996515";
-                    break;
-                case "Elf":
-                    return "#900020";
-                    break;
-                case "Ent":
-                    return "#5b3";
-                    break;
-                case "Falmar/Falas Elf":
-                    return "#0099CC";
-                    break;
-                case "God":
-                    return "#fff";
-                    break;
-                case "Gondorian":
-                    return "#393939";
-                    break;
-                case "Half-Elf":
-                    return "#900020";
-                    break;
-                case "Hobbit":
-                    return "#006600";
-                    break;
-                case "Maia":
-                    return "#9A03B5";
-                    break;
-                case "Man":
-                    return "#993D00";
-                    break;
-                case "Nando":
-                    return "#355E3B";
-                    break;
-                case "Nazgûl":
-                    return "#000";
-                    break;
-                case "Noldo":
-                    return "#090A67";
-                    break;
-                case "Númenórean":
-                    return "#007BA7";
-                    break;
-                case "Orc":
-                    return "#736326";
-                    break;
-                case "Rohir":
-                    return "#80461B";
-                    break;
-                case "Sinda":
-                    return "#949494";
-                    break;
-                case "Spider":
-                    return "#000";
-                    break;
-                case "Teleri":
-                    return "#4B0101";
-                    break;
-                case "Tree":
-                    return "#2b6";
-                    break;
-                case "Troll":
-                    return "#000";
-                    break;
-                case "Vala":
-                    return "#440D60";
-                    break;
-                case "Vanya":
-                    return "#FFCC00";
-                    break;
-                case "Werewolf":
-                    return "#000";
-                    break;
-                default:
-                    return "#aaa";
-                    break;
-            }
-        },
-        mouseover      : function() {
-            d3.select(this).select("text").transition()
-                .duration(750)
-                .style("font-size", "15px")
-                .style("fill", "black");
-            d3.select(this).moveToFront();
-        },
-        mouseout       : function() {
-            d3.select(this).select("text").transition()
-                .duration(750)
-                .style("font-size", "8px")
-                .style("fill", "#ccc");
-        },
-        events         : events,
-        click          : function(d) {
-            events.node_click(d);
-        },
-        dblclick       : function(d) {
-            events.node_dblclick(d);
-        }
-    };
-    function zoomableSVG(size, selector, z) {
-        //delivers an svg background with zoom/drag context in the selector element
-        //if height or width is NaN, assume it is percentage and ignore margin
-        var margin   = size.margin || {top: 0, right: 0, bottom: 0, left: 0},
-            percentW = isNaN(size.width), percentH = isNaN(size.height),
-            w        = percentW ? size.width : size.width - margin.left - margin.right,
-            h        = percentH ? size.height : size.height - margin.top - margin.bottom,
-            zoomed   = function() {
-                return this
-            },
-
-            zoom     = zoom || d3.behavior.zoom().scaleExtent(z && z.extent || [0.4, 4])
-                .on("zoom", function(d, i, j) {
-                    zoomed.call(this, d, i, j);
-                });
-
-        var svg = d3.select(selector).selectAll("svg").data([["transform root"]]);
-        svg.enter().append("svg");
-        svg.attr({width: size.width, height: size.height});
-
-        var g       = svg.selectAll("#zoom").data(id),
-            gEnter  = g.enter().append("g")
-                .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
-                .call(zoom)
-                .attr({class: "outline", id: "zoom"}),
-            surface = gEnter.append("rect")
-                .attr({width: w, height: h, fill: "none"})
-                .style({"pointer-events": "all"});
-        if (z && (typeof z.dblclk != "undefined")) gEnter.on("dblclick.zoom", z.dblclk);
-
-        g.h = h;
-        g.w = w;
-        g.onZoom = function(cb) {
-            zoomed = cb;
+  var svg, link = {}, node;
+  var zoom;
+  var width = 1200, height = 900;
+  var container;
+  var eventNames = ["node_click", "node_dblclick", "node_contextmenu", "graph_init", "force_stage", "force_stop"],
+      events     = d3.dispatch.apply(null, eventNames),
+      markerEnds = d3.range(1, 9).reduce(function(m, d) {
+        return (m[d] = "url(#end" + d + ")", m)
+      }, {}),
+      phasesAlpha = (function(){
+        var p = [0.08, 0.04, 0.02, 0],i = 0;
+        return function (alpha){
+          // resets if alpha is falsey or > p[0]
+          i = alpha ? (alpha > p[0] ? 0 : i) : 0;
+          var i0 = i;
+          if(alpha < (p[i])) i++;
+          return i != i0;
         };
+      })(), // fire the force_stage event when alpha reaches each value
 
-        return g;
+
+    fdg = (function() {
+      var force = d3.layout.force()
+            .size([width, height])
+            .gravity(.2)
+            .charge(-400)
+            .friction(0.9)
+            .theta(0.9)
+            .linkStrength(1)
+            .distance(100)
+            .on("tick", tick)
+            .on("end", events.force_stop),
+          fdg = {};
+
+      svg = zoomableSVG({width: "100%", height: "100%"}, "#familytreecontentsvg", {extent: [0.4, 4], dblclk: null});
+
+      function data(dataSet) {
+        if (!dataSet) return force.nodes().length ? {nodes: force.nodes(), links: force.links()} : null;
+        force
+          .nodes(dataSet.nodes)
+          .links(dataSet.links)
+
+        svg.onZoom(zoomed);
+
+        hookDrag(force.drag(), "dragstart.force", function(d) {
+          //prevent dragging on the nodes from dragging the canvas
+          var e = d3.event.sourceEvent;
+          e.preventDefault();
+          if(e.button != 2) {
+            //left click only
+            e.stopPropagation();
+            d.fixed = e.shiftKey || e.touches && (e.touches.length > 1);
+            events.node_click(d)
+          }
+        });
+        hookDrag(force.drag(), "dragend.force", function(d) {
+          //prevent dragging on the nodes from dragging the canvas
+          var e = d3.event.sourceEvent;
+          d.fixed = e.shiftKey || d.fixed;
+        });
+
+        //DEFs
+        var varsvgMarker = svg.selectAll("defs")
+          .data([["end"]])
+          .enter().append("defs")
+          .selectAll("marker")
+          .data(id)
+          .enter();
+        createMarker(varsvgMarker);
+
+        container = svg.container("#container").data([{nodes: [force.nodes()], links: [force.links()]}]);
+        container.enter().append("g").attr("id", "container");
+
+        var links = container.selectAll(".links").data(function(d) {
+          return d.links
+        });
+        links.enter().append("g").attr("class", "links");
+
+        link = links.selectAll("line").data(id);
+        link.enter().append("line")/*.attr("class", "link")*/;
+        link.exit().remove();
+        link.attr("class", function(d) {
+          if(d.relation == "BEGETS") {
+            return "linkBEGETS";
+          }
+          if(d.relation == "LOVES") {
+            return "linkLOVES";
+          }
+          if(d.relation == "HASSIBLING") {
+            return "linkHASSIBLING";
+          }
+        })
+          .attr("marker-end", function(d) {
+            if(d.relation == "BEGETS") {
+              return markerEnds[d.targetSign] || "url(#end1)"
+            }
+          });
+
+        var nodes = container.selectAll(".nodes").data(function(d) {
+          return d.nodes
+        });
+        nodes.enter().append("g").attr("class", "nodes");
+
+        node = nodes.selectAll(".node").data(id, nodeKey);
+        var newNode = node.enter().append("g").attr("class", "node");
+        node.exit().remove();
+        newNode
+          .on("mouseover", mouseover)
+          .on("mouseout", mouseout)
+          .on("dblclick", function(d) {
+            events.node_dblclick(d);
+          })
+          .on('contextmenu', function(data, index) {
+            d3.event.preventDefault();
+            events.node_contextmenu(data, index);
+          })
+          .call(force.drag);
+        newNode
+          .append("circle")
+          .attr("class", "bgcircle");
+        node.select("circle")
+          .attr("r", function(d) {
+            return Math.abs(posXY(d));
+          })
+          .style("fill", function(d) {
+            return colourRace(d);
+          })
+          .style("stroke", function(d) {
+            return colourRace(d);
+          });
+        newNode
+          .append("svg:image")
+          .attr("class", "circle")
+          .attr("xlink:href", imgHref)
+          .attr("width", function(d) {
+            return sizeXY(d);
+          })
+          .attr("height", function(d) {
+            return sizeXY(d);
+          })
+          .on("error", function() {
+            d3.select(this).style("visibility", "hidden");
+          });
+        node.select("image")
+          .attr("x", function(d) {
+            return posXY(d);
+          })
+          .attr("y", function(d) {
+            return posXY(d);
+          });
+        newNode
+          .append("text")
+          .attr("class", "nodetext");
+        node.select("text")
+          .attr("x", function(d) {
+            return Math.abs(posXY(d) - 5);
+          })
+          .attr("y", 4)
+          .text(function(d) {
+            return d.name;
+          });
+
+        force
+          .start()
+          //.alpha(0.4);
+
+        function hookDrag(target, event, hook) {
+          //hook force.drag behaviour
+          var stdDrag = target.on(event);
+          target.on(event, function(d) {
+            hook.call(this, d);
+            stdDrag.call(this, d);
+          });
+        }
+
+        function zoomed() {
+          if(force.alpha() < 0.01) force.alpha(0.01);
+        }
+
+        function imgHref(d) {
+          return "/pics/arda/creature/" + d.uniquename + "_familytree.png";
+        }
+
+        function nodeKey(d, i) {
+          return this.href ? d3.select(this).attr("href") : imgHref(d);
+        }
+
+        // zoom context services
+        //  content is the target for zoom movements in zoomed
+        d3.rebind(fdg, container, "attr");
+
+        //  access the current transform state in zoom listener coordinates
+        d3.rebind(fdg, svg, "translate");
+
+        events.graph_init();
+
+        return this;
+
+      };  //data
+
+      var zoomTo = svg.zoomTo.bind(null, 1000);
+      fdg.zoomTo = (function() {
+        var _n;
+        return function(n) {
+          if(!n && ! _n) return false;
+          zoomTo(n || _n);
+          _n = n ? n : _n;
+        }
+      })();
+      fdg.zoomTime = (function() {
+        var _t;
+        return function(t) {
+          if(t == undefined) return _t;
+          if(t == null) return (zoomTo = svg.zoomTo, this);
+          zoomTo = svg.zoomTo.bind(null, _t = t);
+          return this;
+        }
+      })();
+
+      fdg.focusNode = (function() {
+        var _datum; // previous datum is stored as default
+        return function(datum) {
+          _datum = datum || _datum;
+          // closure on a reference to the node and transition state
+          var _n = node.filter(function(d) {
+            return _datum === d;
+          }), _trans, _t;
+          // return an object with chainable methods
+          return {
+            highlight: function() {
+              _trans = highlight(_n);
+              return this;
+            },
+            delay    : function(t) {
+              _t = t;
+              return this;
+            },
+            blur     : function() {
+              if(_trans) _trans.each("end.highlight", function() {
+                blur(_n, _t)
+              });
+              else blur(_n);
+              return this;
+            }
+          }
+        }
+      })();
+
+      fdg.data = data;
+
+      return fdg;
+
+      function tick(e) {
+        link
+          .attr("x1", function(d) {
+            return d.source.x;
+          })
+          .attr("y1", function(d) {
+            return d.source.y;
+          })
+          .attr("x2", function(d) {
+            return d.target.x;
+          })
+          .attr("y2", function(d) {
+            return d.target.y;
+          });
+        node
+          .attr("transform", function(d) {
+            return "translate(" + d.x + "," + d.y + ")";
+          });
+        if(phasesAlpha(e.alpha)) events.force_stage(e.alpha);
+      }
+    })().zoomTime(1000);
+  events.on("force_stage.debug", function(a){console.log(a)});
+
+  function mouseover() {
+    highlight(d3.select(this))
+  }
+  function mouseout() {
+    blur(d3.select(this));
+  }
+
+  function highlight(selection){
+    var s = svg.scale(), transition = selection.select("text").transition()
+      .duration(750)
+      .style({"font-size": (s > 1 ? 15 : (15/s).toFixed()) + "px","fill": "black"});
+    selection.moveToFront();
+    return transition;
+  }
+  function blur(selection, delay){
+    selection.select("text").transition()
+      .duration(750)
+      .delay(delay || 0)
+      .style({"font-size": "8px", "fill": "#ccc",stroke: "none"});
+  }
+  function createMarker(svg) {
+    //http://stackoverflow.com/questions/15495762/linking-nodes-of-variable-radius-with-arrows
+    var obj = [38, 43, 50, 54, 60, 65, 70, 80, 85];
+    for(var i = 0; i < obj.length; i++) {
+      svg.append("svg:marker")
+        .attr("id", "end" + (i + 1))
+        .attr("viewBox", "0 -5 10 10")
+        .attr("refX", obj[i])
+        .attr("refY", -0.05)
+        .attr("markerWidth", 6)
+        .attr("markerHeight", 6)
+        .attr("orient", "auto")
+        .append("svg:path")
+        .attr("d", "M0,-4L10,0L0,4");
+    }
+  }
+  function sizeXY(d) {
+    var deflt = -10;
+    return [deflt, 20, 24, 28, 32, 36, 40, 44, 48, 52][d.significance || 0] || deflt;
+  }
+  function posXY(d) {
+    var deflt = 10;
+    return [deflt, -10, -12, -14, -16, -18, -20, -22, -24, -26][d.significance || 0] || deflt;
+  }
+  function colourRace(d) {
+    return {
+        "Ainu"            : "#000",
+        "Arnorian"        : "#5D8AA8",
+        "Balrog"          : "#000",
+        "Dragon"          : "#900",
+        "Dwarf"           : "#996515",
+        "Elf"             : "#900020",
+        "Ent"             : "#5b3",
+        "Falmar/Falas Elf": "#0099CC",
+        "God"             : "#fff",
+        "Gondorian"       : "#393939",
+        "Half-Elf"        : "#900020",
+        "Hobbit"          : "#006600",
+        "Maia"            : "#9A03B5",
+        "Man"             : "#993D00",
+        "Nando"           : "#355E3B",
+        "Nazgûl"          : "#000",
+        "Noldo"           : "#090A67",
+        "Númenórean"      : "#007BA7",
+        "Orc"             : "#736326",
+        "Rohir"           : "#80461B",
+        "Sinda"           : "#949494",
+        "Spider"          : "#000",
+        "Teleri"          : "#4B0101",
+        "Tree"            : "#2b6",
+        "Troll"           : "#000",
+        "Vala"            : "#440D60",
+        "Vanya"           : "#FFCC00",
+        "Werewolf"        : "#000"
+      }[d.race] || "#aaa";
+  }
+
+  return d3.rebind.bind(fdg, {
+    initializeGraph: fdg.data,
+    zoomTo: function(){
+      fdg.zoomTo.apply(this, arguments)
+    },
+    focusNode: fdg.focusNode,
+    events         : events,
+    data: function() {
+      return fdg.data();
+    }
+  }, events, "on").apply(fdg, events);
+
+  function zoomableSVG(size, selector, z) {
+    //delivers an svg background with zoom/drag context in the selector element
+    //if height or width is NaN, assume it is percentage and ignore margin
+    var margin   = size.margin || {top: 0, right: 0, bottom: 0, left: 0},
+        percentW = isNaN(size.width), percentH = isNaN(size.height),
+        w        = percentW ? size.width : size.width - margin.left - margin.right,
+        h        = percentH ? size.height : size.height - margin.top - margin.bottom,
+        zoomStart   = function() {
+          return this
+        },
+        zoomed   = function() {
+          return this
+        },
+        container,
+
+        zoom     = zoom || d3.behavior.zoom().scaleExtent(z && z.extent || [0.4, 4])
+            .on("zoom", function(d, i, j) {
+              onZoom.call(this, d, i, j);
+              zoomed.call(this, d, i, j);
+            })
+            .on("zoomstart", function(d, i, j){
+              onZoomStart.call(this, d, i, j);
+              zoomStart.call(this, d, i, j);
+            });
+
+    var svg = d3.select(selector).selectAll("svg").data([["transform root"]]);
+    svg.enter().append("svg");
+    svg.attr({width: size.width, height: size.height});
+
+    var g       = svg.selectAll("#zoom").data(id),
+        gEnter  = g.enter().append("g")
+          .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
+          .call(zoom)
+          .attr({class: "outline", id: "zoom"}),
+        surface = gEnter.append("rect")
+          .attr({width: w, height: h, fill: "none"})
+          .style({"pointer-events": "all"});
+    if(z && (typeof z.dblclk != "undefined")) gEnter.on("dblclick.zoom", z.dblclk);
+
+    function onZoomStart(){
+      // zoom translate and scale are initially [0,0] and 1
+      // this needs to be aligned with the container to stop
+      // jump back to zero before first jump transition
+      var t = d3.transform(container.attr("transform"));
+      zoom.translate(t.translate); zoom.scale(t.scale[0]);
     }
 
-    function id(d) {
-        return d;
+    function onZoom(){
+      var e = d3.event.sourceEvent,
+          isWheel = e && ((e.type == "mousewheel") || (e.type == "wheel")),
+          t = d3.transform(container.attr("transform"));
+      t.translate = d3.event.translate; t.scale = [d3.event.scale, d3.event.scale];
+      return isWheel ? zoomWheel.call(this, t) : zoomInst.call(this, t)
+    }
+    function zoomInst(t){
+      container.attr("transform", t.toString());
+    }
+    function zoomWheel(t){
+      container.transition().duration(450).attr("transform", t.toString());
     }
 
+    g.h = h;
+    g.w = w;
+
+    g.container = function(selection){
+      var d3_data, d3_datum;
+      if(selection) {
+        container = g.selectAll(selection);
+        // temporarily subclass container
+        d3_data = container.data;
+        // need a reference to the update selection
+        // so force data methods back to here
+        container.data = function() {
+          delete container.data;	// remove the sub-classing
+          return container = d3_data.apply(container, arguments)
+        }
+      }
+      return container;
+    }
+
+    g.onZoom = function(cb) {
+      zoomed = cb;
+    };
+    g.onZoomStart = function(cb) {
+      zoomStart = cb;
+    };
+    g.zoomTo = function(t, p){
+      // map p to the center of the plot surface
+      var s = zoom.scale(), bBox = surface.node().getBBox(),
+          w = bBox.width - infoState.width(), h = bBox.height,
+          p1 = [w/2 - p.x * s, h/2 - p.y * s];
+      container.transition().duration(t).call(zoom.translate(p1).event);
+    };
+    d3.rebind(g, zoom, "translate");
+    d3.rebind(g, zoom, "scale");
+
+    return g;
+  }
+
+  function id(d) {
+    return d;
+  };
 })();
 
 d3.selection.prototype.moveToFront = function() {
-    return this.each(function() {
-        this.parentNode.appendChild(this);
-    });
+  return this.each(function() {
+    this.parentNode.appendChild(this);
+  });
 };
 

--- a/htdocs/js/familytree.js
+++ b/htdocs/js/familytree.js
@@ -1,82 +1,117 @@
 var familytreeController = (function() {
-    var suggestions = "#familytreesearchsuggestions";
-    var suggestionsFamily = "#familytreesearchsuggestionsFamilycreatures";
-    var showAll;
+  var suggestions = "#familytreesearchsuggestions";
+  var suggestionsFamily = "#familytreesearchsuggestionsFamilycreatures";
+  var showAll;
+  var zoomToTransition = 1000;
 
-    $("#familytreecontentclose a").click(function() {
-        $("#familytree").hide();
-        $("#familytreecontent").children().hide();
-        $("#illustrator").css("z-index", "19");
-    });
+  $("#familytreecontentclose a").click(function() {
+    /** TODO?
+     * Add shut-down code for familytree object?
+     */
+    $("#familytree").hide();
+    $("#familytreecontent").children().hide();
+    $("#illustrator").css("z-index", "19");
+    infoState.on("widthChange", null);
+  });
 
-    $("#familytreeShowallbutton").click(function() {
-        showAll = true;
-        orientdb.getFamilytreeAll2(familytree.initializeGraph);
-    });
+  $("#familytreeShowallbutton").click(function() {
+    showAll = true;
+    orientdb.getFamilytreeAll2(familytree.initializeGraph);
+  });
 
-    $("#familytreeHideallbutton").click(function() {
-        orientdb.clearAll(familytree.initializeGraph);
-    });
+  $("#familytreeHideallbutton").click(function() {
+    orientdb.clearAll(familytree.initializeGraph);
+  });
 
-    d3.select('#familytreeUnfixallbutton').on('click', function() {
-        d3.selectAll('#familytreecontentsvg .node')
-            .each(function(d) {
-                d.fixed = false;
-            })
-            .classed("fixed", false)
-    });
+  d3.select('#familytreeUnfixallbutton').on('click', function() {
+    d3.selectAll('#familytreecontentsvg .node')
+      .each(function(d) {
+        d.fixed = false;
+      })
+      .classed("fixed", false)
+  });
 
-    $("#familytreesearch").on('input', function() {
-        if($("#familytreesearch").val() == "") {
-            $(suggestions).hide();
-        } else {
-            $(suggestions).show();
-            orientdb.search4Creature("#familytreesearch", suggestionsFamily);
-        }
-    });
-
-    $("ul" + suggestionsFamily).on('click', 'li', function() {
-        if(showAll) orientdb.clearAll();
-        orientdb.getFamilytreeSingle2(this.id, familytree.initializeGraph);
-        showAll = false;
-        $(this).addClass("active");
-    });
-
-    familytree.events.on("node_dblclick", function(d) {
-        orientdb.getFamilytreeSingle2(d.ID + '|' + d.class, familytree.initializeGraph);
-    });
-
-    familytree.events.on("node_click", function(d) {
-        orientdb.getInfo4CreatureByRID(d.ID);
-    });
-
-    familytree.events.on("node_contextmenu", function(clickedNode) {
-        orientdb.deleteCreatureByRID(clickedNode, familytree.initializeGraph);
-    });
-
-    $("ul" + suggestionsFamily).on('mouseenter mouseleave', 'li', function() {
-        $(this).toggleClass("highlight");
-    });
-
-    $("#familytreesearch").attr('autocomplete', 'off');
-
-    $("#familytreecontentclose").mouseenter(function() {
-        if(ardamap.getCurrentAge() == "") {
-            $("#familytreeinner a").attr("href", "/");
-        }
-        if(ardamap.getCurrentAge() == "first") {
-            $("#familytreeinner a").attr("href", "/ages/first/");
-        }
-        if(ardamap.getCurrentAge() == "second") {
-            $("#familytreeinner a").attr("href", "/ages/second/");
-        }
-        if(ardamap.getCurrentAge() == "third") {
-            $("#familytreeinner a").attr("href", "/ages/third/");
-        }
-    });
-
-    function getRelationships(id, mode) {
-        if(showAll) familytree.cleanPresentation(mode);
-        orientdb.getFamilytreeSingle2(id, familytree.updateGraph);
+  $("#familytreesearch").on('input', function() {
+    if($("#familytreesearch").val() == "") {
+      $(suggestions).hide();
+    } else {
+      $(suggestions).show();
+      orientdb.search4Creature("#familytreesearch", suggestionsFamily);
     }
+  });
+
+  $("ul" + suggestionsFamily).on('click', 'li', function() {
+    //if(showAll)  orientdb.clearAll();
+    var id = this.id.split("|")[0];
+    orientdb.stageFamilytreeSingle(this.id, function() {
+      var n = this.mergeSingle().dataSet(familytree.initializeGraph).nodes[id],
+        stages = "force_stage", stopEvent = "force_stop",
+        eventID = Date.now();
+      if(n) {
+        orientdb.getInfo4CreatureByRID(id);
+        familytree.focusNode(n).highlight();
+        familytree.on([stages, eventID].join("."), function(){
+          familytree.zoomTo(n);
+        });
+        familytree.on([stopEvent, eventID].join("."), function() {
+          familytree.focusNode(n).highlight().delay(2000).blur();
+          familytree.on("." + eventID, null);
+          console.log(familytree.on([stopEvent, eventID].join(".")))
+        })
+      }
+    });
+    //showAll = false;
+    $(this).addClass("active");
+  });
+
+  familytree.on("node_dblclick", function(d) {
+    //familytree.zoomTo(d);
+    // try to get the relationship tree for the selected node and asynchronously
+    // merge it into the current tree if successful
+    orientdb.stageFamilytreeSingle(d.ID + '|' + d.class, function() {
+      this.mergeSingle().dataSet(familytree.initializeGraph)
+    });
+  });
+
+  familytree.on("node_click", function(d) {
+    orientdb.getInfo4CreatureByRID(d.ID);
+  });
+
+  familytree.on("node_contextmenu", function(clickedNode) {
+    orientdb.deleteCreatureByRID(clickedNode, familytree.initializeGraph);
+  });
+
+  $("ul" + suggestionsFamily).on('mouseenter mouseleave', 'li', function() {
+    $(this).toggleClass("highlight");
+  });
+
+  $("#familytreesearch").attr('autocomplete', 'off');
+
+  $("#familytreecontentclose").mouseenter(function() {
+    if(ardamap.getCurrentAge() == "") {
+      $("#familytreeinner a").attr("href", "/");
+    }
+    if(ardamap.getCurrentAge() == "first") {
+      $("#familytreeinner a").attr("href", "/ages/first/");
+    }
+    if(ardamap.getCurrentAge() == "second") {
+      $("#familytreeinner a").attr("href", "/ages/second/");
+    }
+    if(ardamap.getCurrentAge() == "third") {
+      $("#familytreeinner a").attr("href", "/ages/third/");
+    }
+  });
+  function getRelationships(id, mode) {
+    if(showAll) familytree.cleanPresentation(mode);
+    orientdb.getFamilytreeSingle2(id, familytree.updateGraph);
+  }
+
+  familytree.on("graph_init", function(){
+    infoState.on("widthChange", function(deltaW){
+      if(familytree.data()) {
+        familytree.zoomTo();
+        familytree.focusNode().highlight().delay(2000).blur();
+      }
+    })
+  })
 })();

--- a/htdocs/js/info.js
+++ b/htdocs/js/info.js
@@ -1,88 +1,107 @@
-var infosearchsuggestions = "#infoSearchSuggestions";
-var infosearchsuggestionsCreatures = "#familytreesearchsuggestionsCreatures";
-var infosearchsuggestionsLocations = "#familytreesearchsuggestionsLocations";
+infoState = (function() {
+    var infosearchsuggestions = "#infoSearchSuggestions";
+    var infosearchsuggestionsCreatures = "#familytreesearchsuggestionsCreatures";
+    var infosearchsuggestionsLocations = "#familytreesearchsuggestionsLocations";
+    var eventNames = ["widthChange"], events = d3.dispatch.apply(null, eventNames);
 
-$("#infobutton").click(function () {
-    //$("#timelinearea_de_-1-2").css("width","0px");
-    $("#infoContentSearch").hide();
-    var duration = 500;
-    var targetWidth = $('#infoinner').css("width") == "350px" ? "0px" : "350px";
-    if (!$("#infoinner").is(":visible")) {
-        $("#infoinner").show();
-        $("#infobuttons").css("z-index", "22");
-        $("#infobutton").css("z-index", "22");
-        $("#searchbutton").css("z-index", "23");
-        $("#illustrator").css("z-index", "24");
+    function toggle() {
+        var w = width();
+        //$("#timelinearea_de_-1-2").css("width","0px");
+        $("#infoContentSearch").hide();
+        var duration = 500;
+        var targetWidth = $('#infoinner').css("width") == "350px" ? "0px" : "350px";
+        if(!$("#infoinner").is(":visible")) {
+            $("#infoinner").show();
+            $("#infobuttons").css("z-index", "22");
+            $("#infobutton").css("z-index", "22");
+            $("#searchbutton").css("z-index", "23");
+            $("#illustrator").css("z-index", "24");
+        }
+        $('#infoinner').animate({width: targetWidth}, duration, function() {
+            $("#infobutton").addClass("buttonActive");
+            if($(this).css("width") == "0px") {
+                $("#infobutton").removeClass("buttonActive");
+                $(this).hide();
+                $("#infobuttons").css("z-index", "8");
+                $("#infobutton").css("z-index", "8");
+                $("#searchbutton").css("z-index", "9");
+                $("#illustrator").css("z-index", "19");
+            };
+            //console.log(events.widthChange + width() + w) //(width() - w);
+            events.widthChange(width() - w);
+        });
     }
-    $('#infoinner').animate({width: targetWidth}, duration, function () {
-        $("#infobutton").addClass("buttonActive");
-        if ($(this).css("width") == "0px") {
-            $("#infobutton").removeClass("buttonActive");
-            $(this).hide();
-            $("#infobuttons").css("z-index", "8");
-            $("#infobutton").css("z-index", "8");
-            $("#searchbutton").css("z-index", "9");
-            $("#illustrator").css("z-index", "19");
+
+    function width() {
+        return $("#infoinner").width();
+    }
+    $("#infobutton").click(toggle);
+
+    $("#searchbutton").click(function() {
+        $(infosearchsuggestions).hide();
+        if($('#infoinner').css("width") == "0px") {
+            $("#infobutton").click();
+        }
+        $("#infoContentSearch").toggle();
+        $("#infoSearch").focus();
+    });
+
+    $("#infoSearch").on('input', function() {
+        if($("#infoSearch").val() == "") {
+            $(infosearchsuggestions).hide();
+        } else {
+            $(infosearchsuggestions).show();
+            orientdb.search4Creature("#infoSearch", infosearchsuggestionsCreatures);
+            orientdb.search4Location("#infoSearch", infosearchsuggestionsLocations);
         }
     });
-});
 
-$("#searchbutton").click(function () {
-    $(infosearchsuggestions).hide();
-    if ($('#infoinner').css("width") == "0px") {
-        $("#infobutton").click();
+    $("#infoSearch").click(function() {
+        $("#infoSearchSuggestions").toggle();
+    });
+
+    $("#infoSearchSuggestions").on('mouseleave', '', function() {
+        $("#infoSearchSuggestions").hide();
+    });
+
+    $(".infopicture").on('mouseenter mouseleave', '', function() {
+        $(".infopictureSource span").toggleClass("menuelementhighlight");
+    });
+
+    $(".infopicture").click(function() {
+        triggerIllustrator();
+    });
+
+    $(".infopictureSource span").click(function() {
+        triggerIllustrator();
+    });
+
+    function triggerIllustrator() {
+        var illustrator = $(".infopictureSource span").text();
+        var finalString = illustrator.substring(2, illustrator.length);
+        $("#illustratorfooter").hide();
+        $("#illustrator").show();
+        $("#illustratorcontent" + getUnSimplifiedIllustratorName(finalString)).show();
     }
-    $("#infoContentSearch").toggle();
-    $("#infoSearch").focus();
-});
 
-$("#infoSearch").on('input', function () {
-    if ($("#infoSearch").val() == ""){
-        $(infosearchsuggestions).hide();
-    } else {
-        $(infosearchsuggestions).show();
-        orientdb.search4Creature("#infoSearch", infosearchsuggestionsCreatures);
-        orientdb.search4Location("#infoSearch", infosearchsuggestionsLocations);
-    }
-});
+    $(infosearchsuggestions + " ul").on('click', 'li', function() {
+        orientdb.getInfo4CreatureGenRID(this.id);
+        $(this).addClass("active");
+    });
 
-$("#infoSearch").click(function () {
-    $("#infoSearchSuggestions").toggle();
-});
+    $(infosearchsuggestions + " ul").on('mouseenter mouseleave', 'li', function() {
+        $(this).toggleClass("highlight");
+    });
 
-$("#infoSearchSuggestions").on('mouseleave', '', function () {
-    $("#infoSearchSuggestions").hide();
-});
-
-$(".infopicture").on('mouseenter mouseleave', '', function () {
-    $(".infopictureSource span").toggleClass("menuelementhighlight");
-});
-
-$(".infopicture").click(function () {
-    triggerIllustrator();
-});
-
-$(".infopictureSource span").click(function () {
-    triggerIllustrator();
-});
-
-function triggerIllustrator(){
-    var illustrator = $(".infopictureSource span").text();
-    var finalString = illustrator.substring(2, illustrator.length);
-    $("#illustratorfooter").hide();
-    $("#illustrator").show();
-    $("#illustratorcontent" + getUnSimplifiedIllustratorName(finalString)).show();
-}
-
-$(infosearchsuggestions + " ul").on('click', 'li', function () {
-    orientdb.getInfo4CreatureGenRID(this.id);
-    $(this).addClass("active");
-});
-
-$(infosearchsuggestions + " ul").on('mouseenter mouseleave', 'li', function () {
-    $(this).toggleClass("highlight");
-});
-
-$("#infoClosebutton").click(function () {
-    $("#infoContentSearch").hide();
-});
+    $("#infoClosebutton").click(function() {
+        $("#infoContentSearch").hide();
+    });
+    return d3.rebind.bind(null, {
+        width: width,
+        show : function(yes) {
+            if(yes && !infoState.width()) toggle();
+            else if(!yes && infoState.width()) toggle();
+        },
+        events: events
+    }, events, "on").apply(null, events)
+})();

--- a/htdocs/js/orientdb.js
+++ b/htdocs/js/orientdb.js
@@ -1,475 +1,539 @@
 var orientdb = (function() {
 
-    // Data Repository
-    var treeData = (function() {
-        var allJSON       = [],
-            loadedSingles = d3.map(), fetchedSingle;
-        var currentJSON = [], currentLinks = d3.map(), currentNodes = {};
+	// Data Repository
+	var treeData = (function() {
+		var allJSON       = [],
+				loadedSingles = d3.map(), fetchedSingle;
+		var currentJSON = [], currentLinks = d3.map(), currentNodes = {};
 
-        function generateNodes() {
-            currentLinks = d3.map();
-            // connect links to existing nodes or generate new nodes based on links source and target
-            currentJSON.forEach(function(link) {
-                // new links will have strings for source and target, skip others
-                // A filtered version of currentNodes is passed to the force,
-                // so the original node data is retained in it's entirety
-                if(typeof(link.source) == "string") {
-                    link.source = currentNodes[link.source] || (
-                        currentNodes[link.source] = {
-                            name        : link.sourceName,
-                            significance: link.sourceSign,
-                            uniquename  : link.sourceUName,
-                            ID          : link.source,
-                            class       : link.sourceClass,
-                            relation    : link.relation,
-                            race        : link.sourceRace,
-                            linkCount   : 0
-                        }
-                        );
-                    link.source.linkCount++;
-                }
-                if(typeof(link.target) == "string") {
-                    link.target = currentNodes[link.target] || (
-                        currentNodes[link.target] = {
-                            name        : link.targetName,
-                            significance: link.targetSign,
-                            uniquename  : link.targetUName,
-                            ID          : link.target,
-                            class       : link.targetClass,
-                            relation    : link.relation,
-                            race        : link.targetRace,
-                            linkCount   : 0
-                        }
-                        );
-                    link.target.linkCount++;
-                }
-                currentLinks.set(linkKey(link), link)
-            });
-        }
+		function generateNodes() {
+			currentLinks = d3.map();
+			// connect links to existing nodes or generate new nodes based on links source and target
+			currentJSON.forEach(function(link) {
+				// new links will have strings for source and target, skip others
+				// A filtered version of currentNodes is passed to the force,
+				// so the original node data is retained in it's entirety
+				if(typeof(link.source) == "string") {
+					link.source = currentNodes[link.source] || (
+							currentNodes[link.source] = {
+								name        : link.sourceName,
+								significance: link.sourceSign,
+								uniquename  : link.sourceUName,
+								ID          : link.source,
+								class       : link.sourceClass,
+								relation    : link.relation,
+								race        : link.sourceRace,
+								links: d3.map()
+							}
+						);
+					link.source.links.set(linkKey(link), "tail");
+				}
+				if(typeof(link.target) == "string") {
+					link.target = currentNodes[link.target] || (
+							currentNodes[link.target] = {
+								name        : link.targetName,
+								significance: link.targetSign,
+								uniquename  : link.targetUName,
+								ID          : link.target,
+								class       : link.targetClass,
+								relation    : link.relation,
+								race        : link.targetRace,
+								links: d3.map()
+							}
+						);
+					link.target.links.set(linkKey(link), "head");
+				}
+				currentLinks.set(linkKey(link), link)
+			});
+		}
 
-        function linkKey(link) {
-            return (link.source.ID || link.source) + (link.target.ID || link.target)
-        }
+		function linkKey(link) {
+			return (link.source.ID || link.source) + (link.target.ID || link.target)
+		}
 
-        return {
-            JSON        : function(j) {
-                if(j) {
-                    currentJSON = clone(j);
-                    return this
-                } else return currentJSON;
-            },
-            loadedSingle: function(key, value) {
-                if(arguments.length == 2) return (loadedSingles.set(key, (clone(fetchedSingle = value))), this);
-                else return (fetchedSingle = clone(loadedSingles.get(key)))
-            },
-            mergeSingle : function(key) {
-                if(key) this.loadedSingle(key);
-                currentJSON = (currentJSON || []).concat(fetchedSingle.filter(function(l) {
-                    return !currentLinks.has(linkKey(l))
-                }));
-                return this
-            },
-            deleteNode  : function(clickedNode) {
-                // remove links from or to clicked node
-                currentJSON.forEach(function(link, i) {
-                    if(link.source.ID == clickedNode.ID) {
-                        link.target.linkCount--;
-                        delete currentJSON[i];
-                    } else if(link.target.ID == clickedNode.ID) {
-                        link.source.linkCount--;
-                        delete currentJSON[i];
-                    }
-                });
-                currentJSON = currentJSON.filter(function(d) {
-                    return d
-                });
+		return {
+			JSON        : function(j) {
+				if(j) {
+					currentJSON = clone(j);
+					return this
+				} else return currentJSON;
+			},
+			get currentLinks(){return currentLinks},
+			get nodes(){return currentNodes},
+			loadedSingle: function(key, value) {
+				if(arguments.length == 2) return (loadedSingles.set(key, (clone(fetchedSingle = value))), this);
+				else return (fetchedSingle = clone(loadedSingles.get(key)))
+			},
+			get fetchedSingle(){return fetchedSingle},
+			mergeSingle : function(key) {
+				if(key) this.loadedSingle(key);
+				currentJSON = (currentJSON || []).concat(fetchedSingle.filter(function(l) {
+					return !currentLinks.has(linkKey(l))
+				}));
+				return this
+			},
+			deleteNode  : function(clickedNode) {
+				// remove links from or to clicked node
+				currentJSON.forEach(function(link, i) {
+					if(link.source.ID == clickedNode.ID) {
+						if(!link.target.links.remove(linkKey(link))) console.log("remove failed!");
+						delete currentJSON[i];
+					} else if(link.target.ID == clickedNode.ID) {
+						if(!link.source.links.remove(linkKey(link))) console.log("remove failed!");
+						delete currentJSON[i];
+					}
+				});
+				currentJSON = currentJSON.filter(function(d) {
+					return d
+				});
 
-                clickedNode.linkCount = 0;
+				clickedNode.links = d3.map();
 
-                return this;
-            },
-            clearAll    : function() {
-                // bulk delete
-                // delete all links and discard references to them
-                currentJSON = [];
-                currentLinks = d3.map();
-                // set nodes link count to zero, but keep references to the same objects
-                d3.values(currentNodes).forEach(function(d) {
-                    d.linkCount = 0
-                });
-                return this
-            },
-            setAll      : function() {
-                allJSON = clone(currentJSON);
-                return this
-            },
-            getAll      : function() {
-                var exists = allJSON.length;
-                if(exists) currentJSON = clone(allJSON);
-                return exists;
-            },
-            dataSet     : function(callBack) {
-                if(callBack) {
-                    generateNodes();
-                    callBack({
-                        nodes: d3.values(currentNodes).filter(function(d) {
-                            return d.linkCount;
-                        }),
-                        links: currentJSON  //TODO clone? currently not to help generateNodes
-                    });
-                }
-            }
-        }
-    })();
+				return this;
+			},
+			clearAll    : function() {
+				// bulk delete
+				// delete all links and discard references to them
+				currentJSON = [];
+				currentLinks = d3.map();
+				// set nodes link count to zero, but keep references to the same objects
+				d3.values(currentNodes).forEach(function(d) {
+					d.links = d3.map();
+				});
+				return this
+			},
+			setAll      : function() {
+				allJSON = clone(currentJSON);
+				return this
+			},
+			getAll      : function() {
+				var exists = allJSON.length;
+				if(exists) {
+					currentJSON = (currentJSON || []).concat(clone(allJSON).filter(function(l) {
+						return !currentLinks.has(linkKey(l))
+					}));
+				}
+				return exists;
+			},
+			dataSet     : function(callBack) {
+				if(callBack) {
+					generateNodes();
+					callBack({
+						nodes: d3.values(currentNodes).filter(function(d) {
+							return d.links.size();
+						}),
+						links: currentJSON  //TODO clone? currently not to help generateNodes
+					});
+				}
+				return this;
+			}
+		}
+	})();
 
-    // Data Interface
-    return {
-        getFamilytreeAll           : function() {
-            $.ajax({
-                url    : urlOrientDB + "getFamilytreeAll/",
-                headers: {
-                    "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                },
-                success: function(result) {
-                    var jsonResult = result.result;
-                    familytree.createGraph(jsonResult);
-                }
-            });
-        },
-        getFamilytreeAll2          : function(onSuccess) {
-            if(treeData.getAll(onSuccess)) return treeData.dataSet(onSuccess);
-            $.ajax({
-                url    : urlOrientDB + "getFamilytreeAll/",
-                headers: {
-                    "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                },
-                success: function(result) {
-                    treeData.JSON(result.result).setAll().dataSet(onSuccess);
-                }
-            });
-        },
-        getFamilytreeSingle        : function(rid) {
-            var infos = rid.split('|');
-            $.ajax({
-                url    : urlOrientDB + "getFamilytreeSingle/" + infos[0].substring(1, infos[0].length),
-                headers: {
-                    "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                },
-                success: function(result) {
-                    var jsonResult = result.result;
-                    if(familytree.getAlreadyThere()) {
-                        familytree.updateGraph(jsonResult);
-                    } else {
-                        familytree.createGraph(jsonResult);
-                    }
-                }
-            });
-        },
-        getFamilytreeSingle2       : function(rid, onSuccess) {
-            var infos = rid.split('|');
-            if(treeData.loadedSingle(infos[0])) return treeData.mergeSingle().dataSet(onSuccess);
-            $.ajax({
-                url    : urlOrientDB + "getFamilytreeSingle/" + infos[0].substring(1, infos[0].length),
-                headers: {
-                    "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                },
-                success: function(result) {
-                    treeData.loadedSingle(infos[0], result.result);
-                    treeData.mergeSingle().dataSet(onSuccess);
-                }
-            });
-        },
-        getInfo4CreatureGenRID     : function(rid) {
-            var infos = rid.split('|');
-            if(infos[1] == "Creature") {
-                this.getInfo4CreatureByRID(infos[0]);
-            }
-            if(infos[1] == "Location") {
-                this.getInfo4LocationByRID(infos[0]);
-            }
-        },
-        getInfo4CreatureByRID      : function(rid) {
-            $.ajax({
-                url    : urlOrientDB + "getInfo4CreatureByRID/" + rid.substring(1, rid.length),
-                headers: {
-                    "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                },
-                success: function(result) {
-                    orientdb.showInfo4Creature(result);
-                }
-            });
-        },
-        getInfo4CreatureByUName    : function(uname) {
-            $.ajax({
-                url    : urlOrientDB + "getInfo4CreatureByUName/" + uname,
-                headers: {
-                    "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                },
-                success: function(result) {
-                    orientdb.showInfo4Creature(result);
-                }
-            });
-        },
-        deleteCreatureByRID        : function(clickedNode, onSuccess) {
-            treeData.deleteNode(clickedNode).dataSet(onSuccess)
-        },
-        clearAll                   : function(callback) {
-            treeData.clearAll().dataSet(callback)
-        },
-        showInfo4Creature          : function(result) {
-            if($('#infoinner').css("width") == "0px") {
-                $("#infobutton").click()
-            }
-            $("#infoCreature").show();
-            $("#infoLocation").hide();
-            $("#infoEvent").hide();
-            var res = result.result;
-            $("#infoCreature > .infoheader").html(res[0].name);
-            $("#infoCreature > .infosubname").html(res[0].altname[0]);
-            if(res[0].altname[0] == null) {
-                $("#infoCreature > .infosubname").html("");
-            }
-            $("#infoCreature > .infopicture img").attr("src", "/pics/arda/creature/" + res[0].uniquename + ".jpg ");
-            $(".infopictureSource span").text("");
-            if(res[0].illustrator[0] != null) {
-                $("#infoCreature > .infopictureSource span").html("&#169; " + res[0].illustrator);
-            }
-            if(res[0].altname[0] == null) {
-                $("#infoCreature > .infoothernames > .infosubtext").html("-");
-            } else {
-                $("#infoCreature > .infoothernames > .infosubtext").html("<ul></ul>");
-                for(var i = 0; i < res[0].altname.length; i++) {
-                    $("#infoCreature > .infoothernames > .infosubtext ul").append("<li>" + res[0].altname[i] + "</li>");
-                }
-            }
-            switch(res[0].gender) {
-                case "male":
-                    $('.infosex img').attr("src", "/pics/male.png");
-                    $('.infosex img').attr("title", "male");
-                    break;
-                case "female":
-                    $('.infosex img').attr("src", "/pics/female.png");
-                    $('.infosex img').attr("title", "female");
-                    break;
-                default:
-                    $('.infosex img').attr("src", "/pics/unclear.png");
-                    $('.infosex img').attr("title", "sex unclear or mixed");
-                    break;
-            }
-            $('#infoCreature > .inforace > .infosubtext').html(res[0].race);
-            $('#infoCreature > .infolife > .infosubtext').html(res[0].born);
-            $('#infoCreature > .infolife > .infosubtext').html(" until " + res[0].died);
-            $("#infoCreature > .infolocation > .infosubtext").html("<ul></ul>");
-            for(var i = 0; i < res[0].location.length; i++) {
-                $("#infoCreature > .infolocation > .infosubtext ul").append("<li>" + res[0].location[i] + "</li>");
-            }
-            $('#infoCreature > .infolink').html("<a href=" + res[0].gatewaylink + ">More infos on TolkienGateway</a>");
-        },
-        getInfo4EventByUName       : function(uname) {
-            $.ajax({
-                url    : urlOrientDB + "getInfo4EventByUName/" + uname,
-                headers: {
-                    "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                },
-                success: function(result) {
-                    if($('#infoinner').css("width") == "0px") {
-                        $("#infobutton").click()
-                    }
-                    $("#infoCreature").hide();
-                    $("#infoLocation").hide();
-                    $("#infoEvent").show();
-                    var res = result.result;
-                    $("#infoEvent > .infoheader").html(res[0].name);
-                    $("#infoEvent > .infopicture img").attr("src", "/pics/arda/event/" + res[0].uniquename + ".jpg ");
-                    $(".infopictureSource span").text("");
-                    if(res[0].illustrator[0] != null) {
-                        $("#infoEvent > .infopictureSource span").html("&#169; " + res[0].illustrator);
-                    }
-                    //$("#infoEvent > .infopictureSource span").html(res[0].illustrator);
-                    $('#infoEvent > .infodescription > .infosubtext').html(res[0].description);
-                }
-            });
-        },
-        getInfo4LocationByRID      : function(rid) {
-            $.ajax({
-                url    : urlOrientDB + "getInfo4LocationByRID/" + rid.substring(1, rid.length),
-                headers: {
-                    "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                },
-                success: function(result) {
-                    orientdb.showInfo4Location(result);
-                }
-            });
-        },
-        getInfo4LocationByUName    : function(uname) {
-            $.ajax({
-                url    : urlOrientDB + "getInfo4LocationByUName/" + uname,
-                headers: {
-                    "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                },
-                success: function(result) {
-                    orientdb.showInfo4Location(result);
-                }
-            });
-        },
-        showInfo4Location          : function(result) {
-            if($('#infoinner').css("width") == "0px") {
-                $("#infobutton").click()
-            }
-            $("#infoCreature").hide();
-            $("#infoLocation").show();
-            $("#infoEvent").hide();
-            var res = result.result;
-            $("#infoLocation > .infoheader").html(res[0].name);
-            $("#infoLocation > .infosubname").html(res[0].altname[0]);
-            if(res[0].altname[0] == null) {
-                $("#infoLocation > .infosubname").html("");
-            }
-            $("#infoLocation > .infopicture img").attr("src", "/pics/arda/location/" + res[0].uniquename + ".jpg ");
-            $(".infopictureSource span").text("");
-            if(res[0].illustrator[0] != null) {
-                $("#infoLocation > .infopictureSource span").html("&#169; " + res[0].illustrator);
-            }
-            if(res[0].altname[0] == null) {
-                $("#infoLocation > .infoothernames > .infosubtext").html("-");
-            } else {
-                $("#infoLocation > .infoothernames > .infosubtext").html("<ul></ul>");
-                for(var i = 0; i < res[0].altname.length; i++) {
-                    $("#infoLocation > .infoothernames > .infosubtext ul").append("<li>" + res[0].altname[i] + "</li>");
-                }
-            }
-            $("#infoLocation > .infotype img").attr("src", "/pics/other/" + res[0].type + ".png ");
-            $("#infoLocation > .infotype img").attr("title", res[0].type);
-            $("#infoLocation > .infoage img").attr("src", "/pics/other/" + res[0].age + ".png ");
-            $("#infoLocation > .infoage img").attr("title", res[0].age);
-            $("#infoLocation > .infoarea > .infosubtext").html("<ul></ul>");
-            for(var i = 0; i < res[0].area.length; i++) {
-                $("#infoLocation > .infoarea > .infosubtext ul").append("<li>" + res[0].area[i] + "</li>");
-            }
-            $('#infoLocation > .infolink').html("<a href=" + res[0].gatewaylink + ">More infos on TolkienGateway</a>");
-        },
-        search4Creature            : function(inputField, suggField) {
-            var searchName = $(inputField).val();
-            if(/^\w+( \w+)*$/.test(searchName)) {
-                $.ajax({
-                    url    : urlOrientDB + "search4Creature/" + searchName,
-                    headers: {
-                        "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                    },
-                    success: function(result) {
-                        var res = result.result;
-                        if(res.length != 0) {
-                            $("ul" + suggField).empty();
-                            $(suggField).css('visibility', 'visible');
-                            $(suggField).show();
-                            for(var i = 0; i < res.length; i++) {
-                                var fallbackURL = "/pics/arda/creature/UnknownPicture_familytree.png";
-                                var imageURL = "<img src=/pics/arda/creature/" + res[i].uniquename
-                                    + "_familytree.png onerror=this.src='" + fallbackURL + "' width='30' height='30'> ";
-                                $("ul" + suggField).append("<li id=" + res[i].rid + '|' + res[i].class
-                                    + " class='creature'> " + imageURL + "<span>" + res[i].name + "</span>" + "</li>");
-                            }
-                        } else {
-                            $("ul" + suggField).empty();
-                            $("ul" + suggField).append("<li>" + "No Creature with: <b>" + searchName + "</b></li>");
-                        }
-                    }
-                });
-            }
-        },
-        search4Location            : function(inputField, suggField) {
-            var searchName = $(inputField).val();
-            if(/^\w+( \w+)*$/.test(searchName)) {
-                $.ajax({
-                    url    : urlOrientDB + "search4Location/" + searchName,
-                    headers: {
-                        "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                    },
-                    success: function(result) {
-                        var res = result.result;
-                        if(res.length != 0) {
-                            $("ul" + suggField).empty();
-                            $(suggField).css('visibility', 'visible');
-                            $(suggField).show();
-                            for(var i = 0; i < res.length; i++) {
-                                var fallbackURL = "/pics/arda/location/UnknownPicture.png";
-                                var imageURL = "<img src=/pics/arda/location/" + res[i].uniquename
-                                    + ".jpg onerror=this.src='" + fallbackURL + "' width='30' height='30'> ";
-                                $("ul" + suggField).append("<li id=" + res[i].rid + '|' + res[i].class
-                                    + " class='location'> " + imageURL + "<span>" + res[i].name + "</span>" + "</li>");
-                            }
-                        } else {
-                            $("ul" + suggField).empty();
-                            $("ul" + suggField).append("<li>" + "No Location with: <b>" + searchName + "</b></li>");
-                        }
-                    }
-                });
-            }
-        },
-        search4IllustratorCreatures: function(name) {
-            $.ajax({
-                url    : urlOrientDB + "search4IllustratorCreatures/" + name,
-                headers: {
-                    "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                },
-                success: function(result) {
-                    var res = result.result;
-                    for(var i = 0; i < res.length; i++) {
-                        var fallbackURL = "/pics/arda/creature/UnknownPicture.png";
-                        var imageURLRaw1 = "/pics/arda/creature/" + res[i].uniquename + ".jpg";
-                        var imageURL1 = "<img title='" + res[i].name + "' src=" + imageURLRaw1 + " onerror=this.src='"
-                            + fallbackURL + "' width='35' height='25'> ";
-                        var imageURLRaw2 = "/pics/arda/creature/" + res[i].uniquename + "_familytree.png";
-                        var imageURL2 = "<img title='" + res[i].name + "' src=" + imageURLRaw2 + " onerror=this.src='"
-                            + fallbackURL + "' width='30' height='30'> ";
-                        $("#illustratorfooterImagesCreatures").append("<a href=" + imageURLRaw1 + ">" + imageURL1
-                            + "</a>");
-                        $("#illustratorfooterImagesCreaturesFamilytree").append("<a href=" + imageURLRaw2 + ">"
-                            + imageURL2 + "</a>");
-                    }
-                }
-            });
-        },
-        search4IllustratorLocations: function(name) {
-            $.ajax({
-                url    : urlOrientDB + "search4IllustratorLocations/" + name,
-                headers: {
-                    "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                },
-                success: function(result) {
-                    var res = result.result;
-                    for(var i = 0; i < res.length; i++) {
-                        var fallbackURL = "/pics/arda/location/UnknownPicture.png";
-                        var imageURLRaw = "/pics/arda/location/" + res[i].uniquename + ".jpg";
-                        var imageURL = "<img title='" + res[i].name + "' src=" + imageURLRaw + " onerror=this.src='"
-                            + fallbackURL + "' width='35' height='25'> ";
-                        $("#illustratorfooterImagesLocations").append("<a href=" + imageURLRaw + ">" + imageURL
-                            + "</a>");
-                    }
-                }
-            });
-        },
-        search4IllustratorEvents   : function(name) {
-            $.ajax({
-                url    : urlOrientDB + "search4IllustratorEvents/" + name,
-                headers: {
-                    "Authorization": "Basic " + btoa("arda" + ":" + "arda")
-                },
-                success: function(result) {
-                    var res = result.result;
-                    for(var i = 0; i < res.length; i++) {
-                        var fallbackURL = "/pics/arda/event/UnknownPicture.png";
-                        var imageURLRaw = "/pics/arda/event/" + res[i].uniquename + ".jpg";
-                        var imageURL = "<img title='" + res[i].name + "' src=" + imageURLRaw + " onerror=this.src='"
-                            + fallbackURL + "' width='35' height='25'> ";
-                        $("#illustratorfooterImagesEvents").append("<a href=" + imageURLRaw + ">" + imageURL + "</a>");
-                    }
-                }
-            });
-        }
-    };
-    function clone(o) {
-        return o ? JSON.parse(JSON.stringify(o)) : null;
-    }
+	// Data Interface
+	return {
+		treeData: treeData,
+		getFamilytreeAll           : function() {
+			$.ajax({
+				url    : urlOrientDB + "getFamilytreeAll/",
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					var jsonResult = result.result;
+					familytree.createGraph(jsonResult);
+				}
+			});
+		},
+		getFamilytreeAll2          : function(onSuccess) {
+			if(treeData.getAll(onSuccess)) return treeData.dataSet(onSuccess);
+			$.ajax({
+				url    : urlOrientDB + "getFamilytreeAll/",
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					treeData.JSON(result.result).setAll().dataSet(onSuccess);
+				}
+			});
+		},
+		getFamilytreeSingle        : function(rid) {
+			var infos = rid.split('|');
+			$.ajax({
+				url    : urlOrientDB + "getFamilytreeSingle/" + infos[0].substring(1, infos[0].length),
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					var jsonResult = result.result;
+					if(familytree.getAlreadyThere()) {
+						familytree.updateGraph(jsonResult);
+					} else {
+						familytree.createGraph(jsonResult);
+					}
+				}
+			});
+		},
+		getFamilytreeSingle2       : function(rid, onSuccess) {
+			var infos = rid.split('|');
+			if(treeData.loadedSingle(infos[0])) return treeData.mergeSingle().dataSet(onSuccess);
+			$.ajax({
+				url    : urlOrientDB + "getFamilytreeSingle/" + infos[0].substring(1, infos[0].length),
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					treeData.loadedSingle(infos[0], result.result);
+					treeData.mergeSingle().dataSet(onSuccess);
+					console.log(relationships(result.result))
+				}
+			});
+		},
+		stageFamilytreeSingle       : function(rid, then) {
+			var infos = rid.split('|');
+			if(treeData.loadedSingle(infos[0])) return then.call(treeData);
+			$.ajax({
+				url    : urlOrientDB + "getFamilytreeSingle/" + infos[0].substring(1, infos[0].length),
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					treeData.loadedSingle(infos[0], result.result);
+					return then.call(treeData);
+				}
+			});
+		},
+		getInfo4CreatureGenRID     : function(rid) {
+			var infos = rid.split('|');
+			if(infos[1] == "Creature") {
+				this.getInfo4CreatureByRID(infos[0]);
+			}
+			if(infos[1] == "Location") {
+				this.getInfo4LocationByRID(infos[0]);
+			}
+		},
+		getInfo4CreatureByRID      : function(rid) {
+			$.ajax({
+				url    : urlOrientDB + "getInfo4CreatureByRID/" + rid.substring(1, rid.length),
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					result.rid = rid;
+					orientdb.showInfo4Creature(result);
+				}
+			});
+		},
+		getInfo4CreatureByRID2      : function(rid, onSuccess) {
+			$.ajax({
+				url    : urlOrientDB + "getInfo4CreatureByRID/" + rid.substring(1, rid.length),
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					result.rid = rid;
+					onSuccess(result);
+				}
+			});
+		},
+		getInfo4CreatureByUName    : function(uname) {
+			$.ajax({
+				url    : urlOrientDB + "getInfo4CreatureByUName/" + uname,
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					orientdb.showInfo4Creature(result);
+				}
+			});
+		},
+		deleteCreatureByRID        : function(clickedNode, onSuccess) {
+			treeData.deleteNode(clickedNode).dataSet(onSuccess)
+		},
+		clearAll                   : function(callback) {
+			treeData.clearAll().dataSet(callback)
+		},
+		showInfo4Creature          : function(result) {
+			infoState.show(true);
+			$("#infoCreature").show();
+			$("#infoLocation").hide();
+			$("#infoEvent").hide();
+			var res = result.result;
+			$("#infoCreature > .infoheader").html(res[0].name);
+			$("#infoCreature > .infosubname").html(res[0].altname[0]);
+			if(res[0].altname[0] == null) {
+				$("#infoCreature > .infosubname").html("");
+			}
+			$("#infoCreature > .infopicture img").attr("src", "/pics/arda/creature/" + res[0].uniquename + ".jpg ");
+			$(".infopictureSource span").text("");
+			if(res[0].illustrator[0] != null) {
+				$("#infoCreature > .infopictureSource span").html("&#169; " + res[0].illustrator);
+			}
+			if(res[0].altname[0] == null) {
+				$("#infoCreature > .infoothernames > .infosubtext").html("-");
+			} else {
+				$("#infoCreature > .infoothernames > .infosubtext").html("<ul></ul>");
+				for(var i = 0; i < res[0].altname.length; i++) {
+					$("#infoCreature > .infoothernames > .infosubtext ul").append("<li>" + res[0].altname[i] + "</li>");
+				}
+			}
+			switch(res[0].gender) {
+				case "male":
+					$('.infosex img').attr("src", "/pics/male.png");
+					$('.infosex img').attr("title", "male");
+					break;
+				case "female":
+					$('.infosex img').attr("src", "/pics/female.png");
+					$('.infosex img').attr("title", "female");
+					break;
+				default:
+					$('.infosex img').attr("src", "/pics/unclear.png");
+					$('.infosex img').attr("title", "sex unclear or mixed");
+					break;
+			}
+			$('#infoCreature > .inforace > .infosubtext').html(res[0].race);
+			$('#infoCreature > .infolife > .infosubtext').html(res[0].born);
+			$('#infoCreature > .infolife > .infosubtext').html(" until " + res[0].died);
+			$('#infoCreature > .infolife > .infosubtext').html(" until " + res[0].died);
+
+			var rel = d3.select("#infoCreature > .inforelations > .infosubtext");
+			rel.selectAll("ul").data([[""]]).exit().remove();
+			orientdb.stageFamilytreeSingle(result.rid, function() {
+				list(rel.node(), relationships(this.fetchedSingle))
+			});
+			
+			var loc = d3.select("#infoCreature > .infolocation > .infosubtext");
+			loc.selectAll("ul").data([[""]]).exit().remove();
+			list(loc.node(), res[0].location);
+
+			$('#infoCreature > .infolink').html("<a href=" + res[0].gatewaylink + ">More infos on TolkienGateway</a>");
+		},
+		getInfo4EventByUName       : function(uname) {
+			$.ajax({
+				url    : urlOrientDB + "getInfo4EventByUName/" + uname,
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					if($('#infoinner').css("width") == "0px") {
+						$("#infobutton").click()
+					}
+					$("#infoCreature").hide();
+					$("#infoLocation").hide();
+					$("#infoEvent").show();
+					var res = result.result;
+					$("#infoEvent > .infoheader").html(res[0].name);
+					$("#infoEvent > .infopicture img").attr("src", "/pics/arda/event/" + res[0].uniquename + ".jpg ");
+					$(".infopictureSource span").text("");
+					if(res[0].illustrator[0] != null) {
+						$("#infoEvent > .infopictureSource span").html("&#169; " + res[0].illustrator);
+					}
+					//$("#infoEvent > .infopictureSource span").html(res[0].illustrator);
+					$('#infoEvent > .infodescription > .infosubtext').html(res[0].description);
+				}
+			});
+		},
+		getInfo4LocationByRID      : function(rid) {
+			$.ajax({
+				url    : urlOrientDB + "getInfo4LocationByRID/" + rid.substring(1, rid.length),
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					orientdb.showInfo4Location(result);
+				}
+			});
+		},
+		getInfo4LocationByUName    : function(uname) {
+			$.ajax({
+				url    : urlOrientDB + "getInfo4LocationByUName/" + uname,
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					orientdb.showInfo4Location(result);
+				}
+			});
+		},
+		showInfo4Location          : function(result) {
+			if($('#infoinner').css("width") == "0px") {
+				$("#infobutton").click()
+			}
+			$("#infoCreature").hide();
+			$("#infoLocation").show();
+			$("#infoEvent").hide();
+			var res = result.result;
+			$("#infoLocation > .infoheader").html(res[0].name);
+			$("#infoLocation > .infosubname").html(res[0].altname[0]);
+			if(res[0].altname[0] == null) {
+				$("#infoLocation > .infosubname").html("");
+			}
+			$("#infoLocation > .infopicture img").attr("src", "/pics/arda/location/" + res[0].uniquename + ".jpg ");
+			$(".infopictureSource span").text("");
+			if(res[0].illustrator[0] != null) {
+				$("#infoLocation > .infopictureSource span").html("&#169; " + res[0].illustrator);
+			}
+			if(res[0].altname[0] == null) {
+				$("#infoLocation > .infoothernames > .infosubtext").html("-");
+			} else {
+				$("#infoLocation > .infoothernames > .infosubtext").html("<ul></ul>");
+				for(var i = 0; i < res[0].altname.length; i++) {
+					$("#infoLocation > .infoothernames > .infosubtext ul").append("<li>" + res[0].altname[i] + "</li>");
+				}
+			}
+			$("#infoLocation > .infotype img").attr("src", "/pics/other/" + res[0].type + ".png ");
+			$("#infoLocation > .infotype img").attr("title", res[0].type);
+			$("#infoLocation > .infoage img").attr("src", "/pics/other/" + res[0].age + ".png ");
+			$("#infoLocation > .infoage img").attr("title", res[0].age);
+			$("#infoLocation > .infoarea > .infosubtext").html("<ul></ul>");
+			for(var i = 0; i < res[0].area.length; i++) {
+				$("#infoLocation > .infoarea > .infosubtext ul").append("<li>" + res[0].area[i] + "</li>");
+			}
+			$('#infoLocation > .infolink').html("<a href=" + res[0].gatewaylink + ">More infos on TolkienGateway</a>");
+		},
+		search4Creature            : function(inputField, suggField) {
+			var searchName = $(inputField).val();
+			if(/^\w+( \w+)*$/.test(searchName)) {
+				$.ajax({
+					url    : urlOrientDB + "search4Creature/" + searchName,
+					headers: {
+						"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+					},
+					success: function(result) {
+						var res = result.result;
+						if(res.length != 0) {
+							$("ul" + suggField).empty();
+							$(suggField).css('visibility', 'visible');
+							$(suggField).show();
+							for(var i = 0; i < res.length; i++) {
+								var fallbackURL = "/pics/arda/creature/UnknownPicture_familytree.png";
+								var imageURL = "<img src=/pics/arda/creature/" + res[i].uniquename
+									+ "_familytree.png onerror=this.src='" + fallbackURL + "' width='30' height='30'> ";
+								$("ul" + suggField).append("<li id=" + res[i].rid + '|' + res[i].class
+									+ " class='creature'> " + imageURL + "<span>" + res[i].name + "</span>" + "</li>");
+							}
+						} else {
+							$("ul" + suggField).empty();
+							$("ul" + suggField).append("<li>" + "No Creature with: <b>" + searchName + "</b></li>");
+						}
+					}
+				});
+			}
+		},
+		search4Location            : function(inputField, suggField) {
+			var searchName = $(inputField).val();
+			if(/^\w+( \w+)*$/.test(searchName)) {
+				$.ajax({
+					url    : urlOrientDB + "search4Location/" + searchName,
+					headers: {
+						"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+					},
+					success: function(result) {
+						var res = result.result;
+						if(res.length != 0) {
+							$("ul" + suggField).empty();
+							$(suggField).css('visibility', 'visible');
+							$(suggField).show();
+							for(var i = 0; i < res.length; i++) {
+								var fallbackURL = "/pics/arda/location/UnknownPicture.png";
+								var imageURL = "<img src=/pics/arda/location/" + res[i].uniquename
+									+ ".jpg onerror=this.src='" + fallbackURL + "' width='30' height='30'> ";
+								$("ul" + suggField).append("<li id=" + res[i].rid + '|' + res[i].class
+									+ " class='location'> " + imageURL + "<span>" + res[i].name + "</span>" + "</li>");
+							}
+						} else {
+							$("ul" + suggField).empty();
+							$("ul" + suggField).append("<li>" + "No Location with: <b>" + searchName + "</b></li>");
+						}
+					}
+				});
+			}
+		},
+		search4IllustratorCreatures: function(name) {
+			$.ajax({
+				url    : urlOrientDB + "search4IllustratorCreatures/" + name,
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					var res = result.result;
+					for(var i = 0; i < res.length; i++) {
+						var fallbackURL = "/pics/arda/creature/UnknownPicture.png";
+						var imageURLRaw1 = "/pics/arda/creature/" + res[i].uniquename + ".jpg";
+						var imageURL1 = "<img title='" + res[i].name + "' src=" + imageURLRaw1 + " onerror=this.src='"
+							+ fallbackURL + "' width='35' height='25'> ";
+						var imageURLRaw2 = "/pics/arda/creature/" + res[i].uniquename + "_familytree.png";
+						var imageURL2 = "<img title='" + res[i].name + "' src=" + imageURLRaw2 + " onerror=this.src='"
+							+ fallbackURL + "' width='30' height='30'> ";
+						$("#illustratorfooterImagesCreatures").append("<a href=" + imageURLRaw1 + ">" + imageURL1
+							+ "</a>");
+						$("#illustratorfooterImagesCreaturesFamilytree").append("<a href=" + imageURLRaw2 + ">"
+							+ imageURL2 + "</a>");
+					}
+				}
+			});
+		},
+		search4IllustratorLocations: function(name) {
+			$.ajax({
+				url    : urlOrientDB + "search4IllustratorLocations/" + name,
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					var res = result.result;
+					for(var i = 0; i < res.length; i++) {
+						var fallbackURL = "/pics/arda/location/UnknownPicture.png";
+						var imageURLRaw = "/pics/arda/location/" + res[i].uniquename + ".jpg";
+						var imageURL = "<img title='" + res[i].name + "' src=" + imageURLRaw + " onerror=this.src='"
+							+ fallbackURL + "' width='35' height='25'> ";
+						$("#illustratorfooterImagesLocations").append("<a href=" + imageURLRaw + ">" + imageURL
+							+ "</a>");
+					}
+				}
+			});
+		},
+		search4IllustratorEvents   : function(name) {
+			$.ajax({
+				url    : urlOrientDB + "search4IllustratorEvents/" + name,
+				headers: {
+					"Authorization": "Basic " + btoa("arda" + ":" + "arda")
+				},
+				success: function(result) {
+					var res = result.result;
+					for(var i = 0; i < res.length; i++) {
+						var fallbackURL = "/pics/arda/event/UnknownPicture.png";
+						var imageURLRaw = "/pics/arda/event/" + res[i].uniquename + ".jpg";
+						var imageURL = "<img title='" + res[i].name + "' src=" + imageURLRaw + " onerror=this.src='"
+							+ fallbackURL + "' width='35' height='25'> ";
+						$("#illustratorfooterImagesEvents").append("<a href=" + imageURLRaw + ">" + imageURL + "</a>");
+					}
+				}
+			});
+		}
+	};
+	function relationshipsText(r){
+		return r.reduce(function(s, d, i){
+			return (s + [(i ? "\n" : ""), d.sourceName, d.relation, d.targetName].join(" "))
+		}, "")
+	}
+	function relationships(r){
+		return r.map(function(d){
+			return ([d.sourceName, d.relation, d.targetName].join(" "))
+		})
+	}
+	function list(base, rows){
+		var ul = d3.select(base).selectAll("ul")
+					.data([rows]),
+				ulEnter = ul.enter().append("ul"),
+				li = ul.selectAll("li").data(ID);
+		li.enter().append("li");
+		li.exit().remove();
+		li.text(ID)
+
+	}
+	function clone(o) {
+		return o ? JSON.parse(JSON.stringify(o)) : null;
+	}
+	function ID(d){return d}
 
 })();


### PR DESCRIPTION
Hi, sorry for the delay, I was busy with other stuff.
This version has all your later changes and fixes the bugs you saw.  They were happening in screens other than familytree and were due to familytree event listeners not being switched off.  I had added a listener to detect when the info panel is activated and this was firing when you click on a map region.  Now fixed.

Detailed logging of the issues are in [my old repo](https://github.com/cool-Blue/SO-Questions/issues), these are all closed out by this release.  I'll close that repo later and use my fork of yours in future.

I have done basic testing but please confirm that it works the way you want and let me know otherwise.

---
## Release Notes

> _note: add ?w=1 to the end of the url when viewing difs, it will suppress formatting changes!_
> e.g. https://github.com/kwoxer/Arda-Maps/pull/1/files?w=1
### info.css
- added inforelations ul style
### info.js
#### Theme
- add an event to signal changes in width of the info window
   this is to allow family tree to adjust the center of it's graph
  - wrapped in infoState object
  - added an events object (so far only includes widthChange
    function toggle
- added to encapsulate #infobutton.click behaviour
- also emits the widthChange event
  - moved #infobutton.click code into toggle
    function width
- added
  return width, show and events. events also bound directly to the return object

familytree
  Theme
- When a search list entry is clicked, highlight and center the node
- Make this the CONTROLLER, eliminate references between orientdb and familytree-d3 all directed through here
- Listen for graph_init event from familytree-d3 and init width change listener for infoState
### orientdb.js
#### Theme
- Make this the MODEL and all interaction via the CONTROLLER, no reference needed for familytree-d3
- Use d3.map to manage link tables on the nodes instead of link counting
  (this is to support future communications between nodes and links)
- Allow for asynchronous fetches for single nodes, fetches are staged and then later retrieved
- Simplified interface with info.js using infoState object
- Add asynchronous get for updating relationships in the info panel
  (TODO add relationsPanel property to infoState)
- Fixed a bug in the locations update for the info panel
  (TODO add locationsPanel property to infoState)
- Added generalise list management function
  (TODO use this for all lists and move management code to infoState)
### familytree-d3.js
#### Theme
- Make this a VIEW object and send all signalling via the CONTROLLER
- Add behaviour to center a selected node and highlight it
- Encapsulate force state and behaviour in fdg
- Eliminate hard references to the parent object (familytree)
- Removed all unnecessary properties exposed on familytree
- Moved all zoom and drag management into zoomableSVG
- Expose internal state and behaviour by direct binding onto fdg and family tree (use d3.rebind)
- Add start, end and progress events for force, emitted from tick
- Eliminate switch statements, use hash tables instead
- Eliminate the need to access familytree events via .events, bind directly onto famillytree
### index.html
- set version to 3.a
- moved info.js above orientdb.js
